### PR TITLE
Add support for numeric suffixes.

### DIFF
--- a/Syntaxes/Nim.YAML-tmLanguage
+++ b/Syntaxes/Nim.YAML-tmLanguage
@@ -99,23 +99,23 @@ patterns:
 
 - comment: A float literal
   name: constant.numeric.float.decimal.nim
-  match: (?<![\w\x{80}-\x{10FFFF}])(\d[_\d]*((\.[_\d]+([eE][\+\-]?\d[_\d]*)?)|([eE][\+\-]?\d[_\d]*)))('?([fF](32|64|128))|[fFdD])?   #' highlight-flaw-fixer-comment
+  match: (?<![\w\x{80}-\x{10FFFF}])(\d[_\d]*((\.[_\d]+([eE][\+\-]?\d[_\d]*)?)|([eE][\+\-]?\d[_\d]*)))('?([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[fFdD])?   #' highlight-flaw-fixer-comment
 
 - comment: A hexadecimal literal
   name: constant.numeric.integer.hexadecimal.nim
-  match: (?<![\w\x{80}-\x{10FFFF}])(0[xX][0-9A-Fa-f][_0-9A-Fa-f]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?   #' highlight-flaw-fixer-comment
+  match: (?<![\w\x{80}-\x{10FFFF}])(0[xX][0-9A-Fa-f][_0-9A-Fa-f]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?   #' highlight-flaw-fixer-comment
 
 - comment: A base-8 integer literal
   name: constant.numeric.integer.octal.nim
-  match: (?<![\w\x{80}-\x{10FFFF}])(0[ocC][0-7][_0-7]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?   #' highlight-flaw-fixer-comment
+  match: (?<![\w\x{80}-\x{10FFFF}])(0[ocC][0-7][_0-7]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?   #' highlight-flaw-fixer-comment
 
 - comment: A base-2 integer literal
   name: constant.numeric.integer.binary.nim
-  match: (?<![\w\x{80}-\x{10FFFF}])(0(b|B)[01][_01]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?   #' highlight-flaw-fixer-comment
+  match: (?<![\w\x{80}-\x{10FFFF}])(0(b|B)[01][_01]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?   #' highlight-flaw-fixer-comment
 
 - comment: A base-10 integer literal
   name: constant.numeric.integer.decimal.nim
-  match: (?<![\w\x{80}-\x{10FFFF}])(\d[_\d]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?   #' highlight-flaw-fixer-comment
+  match: (?<![\w\x{80}-\x{10FFFF}])(\d[_\d]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?   #' highlight-flaw-fixer-comment
 
 - comment: Language Constants.
   name: constant.language.nim
@@ -251,12 +251,7 @@ patterns:
 
 - comment: Single quoted character literal
   name: string.quoted.single.nim
-  begin: \'
-  end: \'
-  patterns:
-    - include: '#escaped_char'
-    - name: invalid.illegal.character.nim
-      match: ([^\'][^\']+?)   #' highlight-flaw-fixer-comment
+  match: \'(.|\\\w)\'
 
 - comment: Call syntax
   begin: ([\w\x{80}-\x{10FFFF}\`]+)\s*(?=\(|\[.+?\]\s*\()

--- a/Syntaxes/Nim.YAML-tmLanguage
+++ b/Syntaxes/Nim.YAML-tmLanguage
@@ -251,7 +251,15 @@ patterns:
 
 - comment: Single quoted character literal
   name: string.quoted.single.nim
-  match: \'(.|\\\w)\'
+  match: \'([^\\]|\\x[0-9A-Fa-f][0-9A-Fa-f]|\\\d+|\\[abceflnrtv\\\"\'])\'
+
+- comment: Flawed single quoted character literal escaped
+  name: invalid.illegal.character.nim
+  match: \'\\[^abceflnrtv\\\"\']\'
+
+- comment: Flawed single quoted character literal other adjacent
+  name: invalid.illegal.character.nim
+  match: \'[A-Fa-f0-9\x{80}-\x{10FFFF}][A-Fa-f0-9\x{80}-\x{10FFFF}]+\'
 
 - comment: Call syntax
   begin: ([\w\x{80}-\x{10FFFF}\`]+)\s*(?=\(|\[.+?\]\s*\()

--- a/Syntaxes/Nim.tmLanguage
+++ b/Syntaxes/Nim.tmLanguage
@@ -646,9 +646,25 @@
 			<key>comment</key>
 			<string>Single quoted character literal</string>
 			<key>match</key>
-			<string>\'(.|\\\w)\'</string>
+			<string>\'([^\\]|\\x[0-9A-Fa-f][0-9A-Fa-f]|\\\d+|\\[abceflnrtv\\\"\'])\'</string>
 			<key>name</key>
 			<string>string.quoted.single.nim</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Flawed single quoted character literal escaped</string>
+			<key>match</key>
+			<string>\'\\[^abceflnrtv\\\"\']\'</string>
+			<key>name</key>
+			<string>invalid.illegal.character.nim</string>
+		</dict>
+		<dict>
+			<key>comment</key>
+			<string>Flawed single quoted character literal other adjacent</string>
+			<key>match</key>
+			<string>\'[A-Fa-f0-9\x{80}-\x{10FFFF}][A-Fa-f0-9\x{80}-\x{10FFFF}]+\'</string>
+			<key>name</key>
+			<string>invalid.illegal.character.nim</string>
 		</dict>
 		<dict>
 			<key>begin</key>

--- a/Syntaxes/Nim.tmLanguage
+++ b/Syntaxes/Nim.tmLanguage
@@ -278,7 +278,7 @@
 			<key>comment</key>
 			<string>A float literal</string>
 			<key>match</key>
-			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(\d[_\d]*((\.[_\d]+([eE][\+\-]?\d[_\d]*)?)|([eE][\+\-]?\d[_\d]*)))('?([fF](32|64|128))|[fFdD])?</string>
+			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(\d[_\d]*((\.[_\d]+([eE][\+\-]?\d[_\d]*)?)|([eE][\+\-]?\d[_\d]*)))('?([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[fFdD])?</string>
 			<key>name</key>
 			<string>constant.numeric.float.decimal.nim</string>
 		</dict>
@@ -286,7 +286,7 @@
 			<key>comment</key>
 			<string>A hexadecimal literal</string>
 			<key>match</key>
-			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(0[xX][0-9A-Fa-f][_0-9A-Fa-f]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?</string>
+			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(0[xX][0-9A-Fa-f][_0-9A-Fa-f]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?</string>
 			<key>name</key>
 			<string>constant.numeric.integer.hexadecimal.nim</string>
 		</dict>
@@ -294,7 +294,7 @@
 			<key>comment</key>
 			<string>A base-8 integer literal</string>
 			<key>match</key>
-			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(0[ocC][0-7][_0-7]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?</string>
+			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(0[ocC][0-7][_0-7]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?</string>
 			<key>name</key>
 			<string>constant.numeric.integer.octal.nim</string>
 		</dict>
@@ -302,7 +302,7 @@
 			<key>comment</key>
 			<string>A base-2 integer literal</string>
 			<key>match</key>
-			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(0(b|B)[01][_01]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?</string>
+			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(0(b|B)[01][_01]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?</string>
 			<key>name</key>
 			<string>constant.numeric.integer.binary.nim</string>
 		</dict>
@@ -310,7 +310,7 @@
 			<key>comment</key>
 			<string>A base-10 integer literal</string>
 			<key>match</key>
-			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(\d[_\d]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?</string>
+			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(\d[_\d]*)('?(([a-zA-Z\x{80}-\x{10FFFF}][\w\x{80}-\x{10FFFF}]*)|[uUfFdD]))?</string>
 			<key>name</key>
 			<string>constant.numeric.integer.decimal.nim</string>
 		</dict>
@@ -643,27 +643,12 @@
 			</array>
 		</dict>
 		<dict>
-			<key>begin</key>
-			<string>\'</string>
 			<key>comment</key>
 			<string>Single quoted character literal</string>
-			<key>end</key>
-			<string>\'</string>
+			<key>match</key>
+			<string>\'(.|\\\w)\'</string>
 			<key>name</key>
 			<string>string.quoted.single.nim</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#escaped_char</string>
-				</dict>
-				<dict>
-					<key>match</key>
-					<string>([^\'][^\']+?)</string>
-					<key>name</key>
-					<string>invalid.illegal.character.nim</string>
-				</dict>
-			</array>
 		</dict>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
The next release of Nim is supporting numeric suffixes. For example:

```nim
import strutils
type nibble = distinct uint8 # a 4-bit unsigned integer
proc `'nibble`(n: string): nibble =
  # The leading ' is required.
  result = (parseInt(n) and 0x0F).nibble

var x = 5'nibble
```

Because the single quote now has dual purposes the current NimLime highlighter gets confused.

This PR will do two things:

1. Make the numeric literal suffix rules more generic to handle custom suffixes.
2. Change the syntax highlighting for char literals so that it does not include explicit calls to the suffix procedures. for example:

```nim
proc aFour(): nibble =
  4'nibble
var x = aFour()
var y = 'h'
```

As you can see, GitHub is also confused by this. This makes sense since I believe GitHub's filters are based on NimLimes'.

I've marked this as work-in-progress (WIP) because item 2 is not done yet. I'm still wrapping my head around a good way to do it. At the moment, the `invalid.illegal.character.nim` checker is completely disabled. I'd like to carefully add that back in. I might do it as a separate rule rather than as a pattern underneath the current one.

Any and all help is very welcome!