### PR TITLE
remove C subgrammar for `emit`

### DIFF
--- a/Syntaxes/Nim.YAML-tmLanguage
+++ b/Syntaxes/Nim.YAML-tmLanguage
@@ -9,21 +9,22 @@ patterns:
 - include: source.nim.comment
 
 # Sub-Syntax selectors
-- comment: C
-  name:    source.c.embedded.nim
-  patterns:
-  - begin: \{\.(emit:) ?(\"\"\")
-    end:   (\"\"\")\.?
-    captures:
-      '1': {name: keyword.other.nim}
-      '2': {name: comment.syntax.nim}
-    endCaptures:
-      '1': {name: comment.syntax.nim}
-    patterns:
-    - name: keyword.operator.nim
-      begin: \`
-      end: \`
-    - {include: source.c}
+
+# - comment: C
+#   name:    source.c.embedded.nim
+#   patterns:
+#   - begin: \{\.(emit:) ?(\"\"\")
+#     end:   (\"\"\")\.?
+#     captures:
+#       '1': {name: keyword.other.nim}
+#       '2': {name: comment.syntax.nim}
+#     endCaptures:
+#       '1': {name: comment.syntax.nim}
+#     patterns:
+#     - name: keyword.operator.nim
+#       begin: \`
+#       end: \`
+#     - {include: source.c}
 
 - comment: assembly
   name: source.asm.embedded.nim

--- a/Syntaxes/Nim.tmLanguage
+++ b/Syntaxes/Nim.tmLanguage
@@ -16,57 +16,59 @@
 			<key>include</key>
 			<string>source.nim.comment</string>
 		</dict>
-		<dict>
-			<key>comment</key>
-			<string>C</string>
-			<key>name</key>
-			<string>source.c.embedded.nim</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>begin</key>
-					<string>\{\.(emit:) ?(\"\"\")</string>
-					<key>captures</key>
+		<!--
+			<dict>
+				<key>comment</key>
+				<string>C</string>
+				<key>name</key>
+				<string>source.c.embedded.nim</string>
+				<key>patterns</key>
+				<array>
 					<dict>
-						<key>1</key>
+						<key>begin</key>
+						<string>\{\.(emit:) ?(\"\"\")</string>
+						<key>captures</key>
 						<dict>
-							<key>name</key>
-							<string>keyword.other.nim</string>
+							<key>1</key>
+							<dict>
+								<key>name</key>
+								<string>keyword.other.nim</string>
+							</dict>
+							<key>2</key>
+							<dict>
+								<key>name</key>
+								<string>comment.syntax.nim</string>
+							</dict>
 						</dict>
-						<key>2</key>
+						<key>end</key>
+						<string>(\"\"\")\.?</string>
+						<key>endCaptures</key>
 						<dict>
-							<key>name</key>
-							<string>comment.syntax.nim</string>
+							<key>1</key>
+							<dict>
+								<key>name</key>
+								<string>comment.syntax.nim</string>
+							</dict>
 						</dict>
+						<key>patterns</key>
+						<array>
+							<dict>
+								<key>begin</key>
+								<string>\`</string>
+								<key>end</key>
+								<string>\`</string>
+								<key>name</key>
+								<string>keyword.operator.nim</string>
+							</dict>
+							<dict>
+								<key>include</key>
+								<string>source.c</string>
+							</dict>
+						</array>
 					</dict>
-					<key>end</key>
-					<string>(\"\"\")\.?</string>
-					<key>endCaptures</key>
-					<dict>
-						<key>1</key>
-						<dict>
-							<key>name</key>
-							<string>comment.syntax.nim</string>
-						</dict>
-					</dict>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>begin</key>
-							<string>\`</string>
-							<key>end</key>
-							<string>\`</string>
-							<key>name</key>
-							<string>keyword.operator.nim</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>source.c</string>
-						</dict>
-					</array>
-				</dict>
-			</array>
-		</dict>
+				</array>
+			</dict>
+                -->
 		<dict>
 			<key>comment</key>
 			<string>assembly</string>


### PR DESCRIPTION
For some reason this is buggy, using `{.emit: [a, b, c].}` completely removes highlighting of some files on github.

Keeping these commented as they may be reused for something like `cLang"""..."""` 