### PR TITLE
Fix pragmas

### DIFF
--- a/Syntaxes/Nim.YAML-tmLanguage
+++ b/Syntaxes/Nim.YAML-tmLanguage
@@ -518,7 +518,7 @@ repository:
             name: entity.other.attribute-name.pragma.nim
           - include: '#square-brackets'
           - begin: (?=\S)
-            end: '(,)|(?=\S)'
+            end: '(,)|(?=\.?})'
             endCaptures:
               '1': {name: punctuation.separator.sequence.nim}
             patterns:

--- a/Syntaxes/Nim.tmLanguage
+++ b/Syntaxes/Nim.tmLanguage
@@ -2118,7 +2118,7 @@
 							<key>begin</key>
 							<string>(?=\S)</string>
 							<key>end</key>
-							<string>(,)|(?=\S)</string>
+							<string>(,)|(?=\.?})</string>
 							<key>endCaptures</key>
 							<dict>
 								<key>1</key>

--- a/Syntaxes/Nim_Filter.YAML-tmLanguage
+++ b/Syntaxes/Nim_Filter.YAML-tmLanguage
@@ -531,7 +531,7 @@ repository:
             name: entity.other.attribute-name.pragma.nim_filter
           - include: '#square-brackets'
           - begin: (?=\S)
-            end: '^(?! *#)|(,)|(?=\S)'
+            end: '^(?! *#)|(,)|(?=\.?})'
             endCaptures:
               '1': {name: punctuation.separator.sequence.nim_filter}
             patterns:

--- a/Syntaxes/Nim_Filter.tmLanguage
+++ b/Syntaxes/Nim_Filter.tmLanguage
@@ -2168,7 +2168,7 @@
 							<key>begin</key>
 							<string>(?=\S)</string>
 							<key>end</key>
-							<string>^(?! *#)|(,)|(?=\S)</string>
+							<string>^(?! *#)|(,)|(?=\.?})</string>
 							<key>endCaptures</key>
 							<dict>
 								<key>1</key>


### PR DESCRIPTION
* Sublime Text and Github's grammar parsers are different. It works fine in ST, but it breaks github's.
```nim
when defined(gcc) and defined(windows):
  when defined(x86):
    {.link: "icons/koch.res".}
  else:
    {.link: "icons/koch_icon.o".}

when defined(amd64) and defined(windows) and defined(vcc):
  {.link: "icons/koch-amd64-windows-vcc.res".}
when defined(i386) and defined(windows) and defined(vcc):
  {.link: "icons/koch-i386-windows-vcc.res".}

import std/[os, strutils, parseopt, osproc]
  # Using `std/os` instead of `os` to fail early if config isn't set up properly.
  # If this fails with: `Error: cannot open file: std/os`, see
  # https://github.com/nim-lang/Nim/pull/14291 for explanation + how to fix.

when defined(nimPreviewSlimSystem):
  import std/[assertions, syncio]
```
@Varriount. Please merge asap !